### PR TITLE
Fix backup / restore not working at all when using a SD2SP2 & Improve autoexec-ldr.c

### DIFF
--- a/source/autoexec-ldr.c
+++ b/source/autoexec-ldr.c
@@ -7,6 +7,9 @@ https://github.com/EnterpriseFreak-v2/autoexec-ldr/releases/tag/v1.00-rewrite
 #include <string.h>
 #include <malloc.h>
 
+#include <fat.h>
+#include <sdcard/gcsd.h>
+
 typedef struct _dolheader {
 	u32 text_pos[7];
 	u32 data_pos[11];
@@ -43,6 +46,10 @@ int bootAutoexec(int argc, char **argv)
 
     fread(dolBuf, 1, dolSize, targetDol);
     fclose(targetDol);
+    fatUnmount("fat");
+    __io_gcsda.shutdown();
+    __io_gcsdb.shutdown();
+    __io_gcsd2.shutdown();
 
     u8* buf;
     u32 size = 0;

--- a/source/main.c
+++ b/source/main.c
@@ -175,7 +175,7 @@ static int initFAT(int device)
 		__io_gcsd2.startup();
 		if(!__io_gcsd2.isInserted())
 		{
-			WaitPrompt("No SD2DP2 inserted! Insert it into serial port 2 and restart");
+			WaitPrompt("No SD2SP2 inserted! Insert it into serial port 2 and restart");
 			return 0;
 		}
 
@@ -829,7 +829,17 @@ int main ()
 #else
 	//Returns 1 (memory card in slot B, sd gecko in slot A) if A button was pressed and 0 if B button was pressed
 	MEM_CARD = WaitPromptChoiceYBA ("Please select where the SD card is located.", "SD2SP2", "SLOT B", "SLOT A");
+
 	have_sd = initFAT(MEM_CARD);
+
+	if (MEM_CARD == 2) {
+		if (WaitPromptChoice("Please select which memory card to use.", "Memory Card B", "Memory Card A") == 1) {
+			MEM_CARD = CARD_SLOTA;
+		}
+		else {
+			MEM_CARD = CARD_SLOTB;
+		}
+	}
 #endif
 
 

--- a/source/main.c
+++ b/source/main.c
@@ -42,7 +42,7 @@ extern int bootAutoexec(void);
 //Comment FLASHIDCHECK to allow writing any image to any mc. This will corrupt official cards.
 #define FLASHIDCHECK
 
-const char appversion[] = "v1.4f";
+const char appversion[] = "v1.5a";
 int mode;
 int cancel;
 int doall;
@@ -198,10 +198,9 @@ void deinitFAT()
 	__io_wiisd.shutdown();
 	__io_usbstorage.shutdown();
 #else
-	if(MEM_CARD)
-		__io_gcsda.shutdown();
-	if(!MEM_CARD)
-		__io_gcsdb.shutdown();
+    __io_gcsda.shutdown();
+    __io_gcsdb.shutdown();
+    __io_gcsd2.shutdown();
 #endif
 }
 


### PR DESCRIPTION
Creating backups and restoring them onto a Memory Card when using the SD2SP2 adapter was impossible as using it would set the ID of the memory card to use to 2 which does not exist. This is fixed by asking the user what Memory Card (slot) he or she would like to use when selecting the SD2SP2 as device with the SD card inserted.

autoexec-ldr.c now unmounts the filesystem of the SD card and shutdown all SD adapters before executing the autoexec.dol,